### PR TITLE
Updates from develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,13 @@ Please see the
 
 - [Tutorial](./doc/tutorial)
 - [チュートリアル(日本語)](./doc/tutorial_ja)
+
+## FAQ
+
+- Q: How to change Redis connection address / port?
+
+  A: Send `#targetUrl:` to `RsStreamSettings` default instance:
+
+  ```Smalltalk
+  RsStreamSettings default targetUrl: 'sync://localhost:6379'
+  ```

--- a/src/Historia-Event/HsCommandEvent.class.st
+++ b/src/Historia-Event/HsCommandEvent.class.st
@@ -39,9 +39,9 @@ HsCommandEvent >> executeOn: modelSpace [
 		               self logger warn:
 			               '#executeOn: no target on modelSpace: '
 			               , self targetId asString.
-		               ^ self ].
-	targetModel handleSinked: self.
-	super executeOn: modelSpace.
+		               nil ].
+	targetModel ifNotNil: [ targetModel handleSinked: self ].
+	super executeOn: modelSpace
 ]
 
 { #category : 'comparing' }

--- a/src/Historia-Event/HsEvent.class.st
+++ b/src/Historia-Event/HsEvent.class.st
@@ -38,7 +38,10 @@ HsEvent class >> id: eventId [
 HsEvent class >> id: eventId data: eventData [
 	| type eventClass |
 	type := eventData at: #tp ifAbsent: [ self name ].
-	eventClass := EventClasses at: type ifAbsent: [ self ].
+	eventClass := EventClasses at: type ifAbsent: [
+		              self logger warn:
+			              'No such event type registered: ' , type.
+		              self ].
 	^ (eventClass id: eventId) readFromCompactDictionary: eventData
 ]
 
@@ -46,6 +49,11 @@ HsEvent class >> id: eventId data: eventData [
 HsEvent class >> initialize [
 	EventClasses := Dictionary new.
 	self registerAll
+]
+
+{ #category : 'logging' }
+HsEvent class >> logger [
+	^ HsLogger default
 ]
 
 { #category : 'instance creation' }
@@ -218,7 +226,7 @@ HsEvent >> isReplayable [
 
 { #category : 'accessing' }
 HsEvent >> logger [
-	^ HsLogger default
+	^ self class logger
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
This pull request introduces enhancements to logging, error handling, and documentation in the `Historia-Event` package and its associated files. Key changes include adding a logger for event classes, improving safety checks for event handling, and updating the `README.md` with a new FAQ section.

### Logging Enhancements:
* Added a `logger` method to the `HsEvent` class, enabling centralized logging via `HsLogger default`. This method is now used in instances and class-level logging. (`src/Historia-Event/HsEvent.class.st`, [[1]](diffhunk://#diff-23a9323e2388dabb47103a2946956ef259c5f79a35ea33c376d657e43f12705bR54-R58) [[2]](diffhunk://#diff-23a9323e2388dabb47103a2946956ef259c5f79a35ea33c376d657e43f12705bL221-R229)

### Error Handling Improvements:
* Updated `HsCommandEvent >> executeOn:` to handle cases where `targetModel` is `nil`, preventing potential errors by adding a safety check before invoking `handleSinked:`. (`src/Historia-Event/HsCommandEvent.class.st`, [src/Historia-Event/HsCommandEvent.class.stL42-R44](diffhunk://#diff-160be40f8c153cebdfe2a33de01091a8e12bf0d20ae74dd1bfcbfe38737e0e65L42-R44))
* Modified `HsEvent class >> id: eventId` to include a warning log when an unregistered event type is encountered, improving visibility into potential misconfigurations. (`src/Historia-Event/HsEvent.class.st`, [src/Historia-Event/HsEvent.class.stL41-R44](diffhunk://#diff-23a9323e2388dabb47103a2946956ef259c5f79a35ea33c376d657e43f12705bL41-R44))

### Documentation Updates:
* Added an FAQ section to the `README.md`, including instructions on how to change the Redis connection address/port using the `RsStreamSettings` default instance. (`README.md`, [README.mdR69-R78](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R69-R78))