### PR TITLE
Updates from develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## Installation
 
-In Playgraoud:
+In Playground:
 
 ```smalltalk
 Metacello new

--- a/src/Historia-Event/HsEvent.class.st
+++ b/src/Historia-Event/HsEvent.class.st
@@ -89,7 +89,7 @@ HsEvent class >> typeName [
 HsEvent >> = aEventRecord [
 	aEventRecord ifNil: [^ false].	
 	self typeName == aEventRecord typeName ifFalse: [^ false].
-	self eventId == aEventRecord eventId ifFalse: [^ false].
+	self eventId = aEventRecord eventId ifFalse: [^ false].
 	^ true
 ]
 

--- a/src/Historia-Storage/HsEventJournalStorage.class.st
+++ b/src/Historia-Storage/HsEventJournalStorage.class.st
@@ -88,6 +88,16 @@ HsEventJournalStorage >> eventVersionsReversedFromLast: limit [
 ]
 
 { #category : 'actions' }
+HsEventJournalStorage >> eventsDo: iterationBlock limit: limit [
+	| count countAndDo |
+	count := 0.
+	countAndDo := [ :entry |
+	              iterationBlock value: (HsEvent fromStreamEntry: entry).
+	              count := count + 1 ].
+	^ self streamIterator do: countAndDo whileFalse: [ limit <= count ]
+]
+
+{ #category : 'actions' }
 HsEventJournalStorage >> eventsFrom: fromMessageId to: toMessageId [
 	| events |
 	events := OrderedCollection new.

--- a/src/Historia-Storage/HsEventJournalStorage.class.st
+++ b/src/Historia-Storage/HsEventJournalStorage.class.st
@@ -54,6 +54,13 @@ HsEventJournalStorage >> deleteEventAt: aMessageId [
 ]
 
 { #category : 'actions' }
+HsEventJournalStorage >> deleteEventsAfter: fromMessageId [
+	| eventIds |
+	eventIds := (self streamIteratorNextFrom: fromMessageId) collect: [:each | each id].
+	^ self deleteEventsAtAll: eventIds 
+]
+
+{ #category : 'actions' }
 HsEventJournalStorage >> deleteEventsAtAll: messageIds [ 
 	| deletedCount |
 	deletedCount := self eventStream deleteAtIds: messageIds.
@@ -61,10 +68,10 @@ HsEventJournalStorage >> deleteEventsAtAll: messageIds [
 ]
 
 { #category : 'actions' }
-HsEventJournalStorage >> deleteEventsFrom: fromMessageId [
+HsEventJournalStorage >> deleteEventsBefore: fromMessageId [
 	| eventIds |
-	eventIds := (self latestEventsFrom: fromMessageId) collect: [:each | each id].
-	^ self streamIterator deleteAtIds: eventIds 
+	eventIds := (self streamIteratorNextFrom: fromMessageId) reversed collect: [:each | each id].
+	^ self deleteEventsAtAll: eventIds 
 ]
 
 { #category : 'accessing' }

--- a/src/Historia-Storage/HsEventJournalStorage.class.st
+++ b/src/Historia-Storage/HsEventJournalStorage.class.st
@@ -47,6 +47,20 @@ HsEventJournalStorage >> codecType [
 ]
 
 { #category : 'actions' }
+HsEventJournalStorage >> deleteEventAt: aMessageId [ 
+	| deletedCount |
+	deletedCount := self eventStream deleteAt: aMessageId.
+	^ deletedCount = 1 
+]
+
+{ #category : 'actions' }
+HsEventJournalStorage >> deleteEventsAtAll: messageIds [ 
+	| deletedCount |
+	deletedCount := self eventStream deleteAtIds: messageIds.
+	^ deletedCount 
+]
+
+{ #category : 'actions' }
 HsEventJournalStorage >> deleteEventsFrom: fromMessageId [
 	| eventIds |
 	eventIds := (self latestEventsFrom: fromMessageId) collect: [:each | each id].
@@ -56,6 +70,11 @@ HsEventJournalStorage >> deleteEventsFrom: fromMessageId [
 { #category : 'accessing' }
 HsEventJournalStorage >> eventStream [
 	^ eventStream ifNil: [ eventStream := HsUtils default newEventStreamNamed: self spaceId ]
+]
+
+{ #category : 'actions' }
+HsEventJournalStorage >> eventVersionsFrom: version limit: limit [
+	^ (self streamIterator contentsFrom: version count: limit) collect: [ :each | each id ]
 ]
 
 { #category : 'actions' }
@@ -110,15 +129,6 @@ HsEventJournalStorage >> lastEventVersion [
 HsEventJournalStorage >> latestEventsFrom: fromMessageId [
 	^ (self streamIteratorNextFrom: fromMessageId) collect: [ :entry |
 		  HsEvent fromStreamEntry: entry ]
-]
-
-{ #category : 'actions' }
-HsEventJournalStorage >> markBadEventAt: aMessageId [ 
-	| event deletedCount |
-	event := self eventStream contentAt: aMessageId.
-	event ifNil: [ ^ self ].
-	deletedCount := self eventStream deleteAt: aMessageId.
-	^ deletedCount = 1 
 ]
 
 { #category : 'actions' }

--- a/src/Historia-Tests/HsEventJournalStorageTestCase.class.st
+++ b/src/Historia-Tests/HsEventJournalStorageTestCase.class.st
@@ -76,6 +76,38 @@ HsEventJournalStorageTestCase >> testBuildSendingPerformCommandData [
 ]
 
 { #category : 'tests' }
+HsEventJournalStorageTestCase >> testEventVersionsFromLimit [
+	| spaceId modelSpace vmodel all firstThree nextSix uptoLast |
+	spaceId := 'hs-ejEventVersionsFromLimit'.
+	modelSpace := HsModelSpace spaceId: spaceId.
+	self spaces: { modelSpace } do: [
+	modelSpace putModel: (HsOrderedCollectionModel id: 'vals-1').
+	vmodel := modelSpace modelAt: 'vals-1'.
+	modelSpace startPushingEvents.
+	1 to: 50 do: [ :idx | 
+		vmodel add: idx.
+		vmodel save.
+	].
+	modelSpace eventPusher waitEmptyFor: 100. 
+	all := modelSpace eventJournalStorage allEvents.
+	self assert: all size equals: 50.
+	firstThree := OrderedCollection new.
+	modelSpace eventJournalStorage eventsDo: [ :ev | firstThree add: ev ] limit: 3.
+	nextSix := modelSpace eventJournalStorage eventVersionsFrom: firstThree last eventId limit: 6.
+	
+	self assertCollection: firstThree asArray equals: (all first: 3) asArray.
+	self assert: firstThree last eventId equals: nextSix first.
+	self assertCollection: nextSix asArray equals: ((all copyFrom: 3 to: 8) collect: [:e | e eventId]) asArray.
+	
+	uptoLast := modelSpace eventJournalStorage eventVersionsFrom: nextSix last limit: 100.
+	self assert: nextSix last equals: uptoLast first.
+	self assertCollection: uptoLast asArray equals: ((all copyFrom: 8 to: 50) collect: [:e | e eventId]) asArray.
+	
+	]
+	
+]
+
+{ #category : 'tests' }
 HsEventJournalStorageTestCase >> testEventVersionsReversedFromLast [
 	| spaceId modelSpace vmodel all lastFive |
 	spaceId := 'hs-ejEventVersionsReversedFromLast'.

--- a/src/Historia-Tests/HsEventJournalStorageTestCase.class.st
+++ b/src/Historia-Tests/HsEventJournalStorageTestCase.class.st
@@ -76,6 +76,89 @@ HsEventJournalStorageTestCase >> testBuildSendingPerformCommandData [
 ]
 
 { #category : 'tests' }
+HsEventJournalStorageTestCase >> testDeleteEventAt [
+	| spaceId modelSpace vmodel all third deleted trimmed |
+	spaceId := 'hs-ejDeleteEventAt'.
+	modelSpace := HsModelSpace spaceId: spaceId.
+	self spaces: { modelSpace } do: [
+	modelSpace putModel: (HsOrderedCollectionModel id: 'vals-1').
+	vmodel := modelSpace modelAt: 'vals-1'.
+	modelSpace startPushingEvents.
+	1 to: 5 do: [ :idx | 
+		vmodel add: idx.
+		vmodel save.
+	].
+	modelSpace eventPusher waitEmptyFor: 50. 
+	all := modelSpace eventJournalStorage allEvents.
+	self assert: all size equals: 5.
+	third := all third.
+	deleted := modelSpace eventJournalStorage deleteEventAt: third eventId.
+	self assert: deleted.
+	trimmed := modelSpace eventJournalStorage allEvents.
+	self assert: trimmed size equals: 4.
+	self assertCollection: trimmed asArray equals: (all copyWithoutIndex: 3) asArray
+	]
+	
+]
+
+{ #category : 'tests' }
+HsEventJournalStorageTestCase >> testDeleteEventsAfter [
+	| spaceId modelSpace vmodel all firstEight fromMessageId deletedCount trimmed |
+	spaceId := 'hs-ejDeleteEventsAfter'.
+	modelSpace := HsModelSpace spaceId: spaceId.
+	self spaces: { modelSpace } do: [
+	modelSpace putModel: (HsOrderedCollectionModel id: 'vals-1').
+	vmodel := modelSpace modelAt: 'vals-1'.
+	modelSpace startPushingEvents.
+	1 to: 20 do: [ :idx | 
+		vmodel add: idx.
+		vmodel save.
+	].
+	modelSpace eventPusher waitEmptyFor: 100. 
+	all := modelSpace eventJournalStorage allEvents.
+	self assert: all size equals: 20.
+	firstEight := OrderedCollection new.
+	modelSpace eventJournalStorage eventsDo: [ :ev | firstEight add: ev ] limit: 8.
+	fromMessageId := firstEight last eventId.
+	deletedCount := modelSpace eventJournalStorage deleteEventsAfter: fromMessageId.
+	self assert: deletedCount equals: 12.
+	trimmed := modelSpace eventJournalStorage allEvents.
+	self assert: trimmed size equals: 8.
+	self assert: trimmed first equals: firstEight first.
+	self assert: trimmed last equals: firstEight last
+	]
+	
+]
+
+{ #category : 'tests' }
+HsEventJournalStorageTestCase >> testDeleteEventsBefore [
+	| spaceId modelSpace vmodel all firstSix fromMessageId deletedCount trimmed |
+	spaceId := 'hs-ejDeleteEventsBefore'.
+	modelSpace := HsModelSpace spaceId: spaceId.
+	self spaces: { modelSpace } do: [
+	modelSpace putModel: (HsOrderedCollectionModel id: 'vals-1').
+	vmodel := modelSpace modelAt: 'vals-1'.
+	modelSpace startPushingEvents.
+	1 to: 20 do: [ :idx | 
+		vmodel add: idx.
+		vmodel save.
+	].
+	modelSpace eventPusher waitEmptyFor: 100. 
+	all := modelSpace eventJournalStorage allEvents.
+	self assert: all size equals: 20.
+	firstSix := OrderedCollection new.
+	modelSpace eventJournalStorage eventsDo: [ :ev | firstSix add: ev ] limit: 6.
+	fromMessageId := firstSix last eventId.
+	deletedCount := modelSpace eventJournalStorage deleteEventsBefore: fromMessageId.
+	self assert: deletedCount equals: 5.
+	trimmed := modelSpace eventJournalStorage allEvents.
+	self assert: trimmed size equals: 15.
+	self assert: trimmed first equals: firstSix last
+	]
+	
+]
+
+{ #category : 'tests' }
 HsEventJournalStorageTestCase >> testEventVersionsFromLimit [
 	| spaceId modelSpace vmodel all firstThree nextSix uptoLast |
 	spaceId := 'hs-ejEventVersionsFromLimit'.


### PR DESCRIPTION
This pull request introduces several changes across documentation, core functionality, and testing for the `HsEventJournalStorage` class and related components. Key updates include fixing a typo in the documentation, improving equality checks for `HsEvent`, adding new methods for event deletion and retrieval, and expanding test coverage to ensure correctness of the new functionality.

### Documentation Fix:
* Corrected a typo in `README.md` ("Playgraoud" to "Playground").

### Core Functionality Enhancements:
* Updated the equality check in `HsEvent` to use `=` instead of `==` for comparing `eventId` for better consistency. (`src/Historia-Event/HsEvent.class.st`)
* Added new methods to `HsEventJournalStorage` for more granular event deletion and retrieval:
  - `deleteEventAt:`, `deleteEventsAfter:`, `deleteEventsBefore:`, and `deleteEventsAtAll:` for managing event deletions. (`src/Historia-Storage/HsEventJournalStorage.class.st`)
  - `eventsDo:limit:` for iterating over events with a limit.
  - Removed the `markBadEventAt:` method as part of cleanup.

### Test Suite Expansion:
* Added new test cases in `HsEventJournalStorageTestCase` to validate the new deletion and retrieval methods:
  - `testDeleteEventAt`, `testDeleteEventsAfter`, `testDeleteEventsBefore`, and `testEventVersionsFromLimit`. (`src/Historia-Tests/HsEventJournalStorageTestCase.class.st`)

These changes collectively enhance the functionality, reliability, and maintainability of the `HsEventJournalStorage` class while ensuring thorough test coverage.