### PR TITLE
Added MessagePack codec support

### DIFF
--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -3,7 +3,7 @@ SmalltalkCISpec {
     SCIMetacelloLoadSpec {
       #baseline : 'Historia',
       #directory : 'src',
-      #load : [ 'Tests', 'Examples-Tests' 'MessagePackCodec-Tests'],
+      #load : [ 'Tests', 'Examples-Tests', 'MessagePackCodec-Tests'],
       #onConflict : #useLoaded,
       #useLatestMetacello : false,
       #onWarningLog : true,

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -3,7 +3,7 @@ SmalltalkCISpec {
     SCIMetacelloLoadSpec {
       #baseline : 'Historia',
       #directory : 'src',
-      #load : [ 'Tests', 'Examples-Tests'],
+      #load : [ 'Tests', 'Examples-Tests' 'MessagePackCodec-Tests'],
       #onConflict : #useLoaded,
       #useLatestMetacello : false,
       #onWarningLog : true,

--- a/README.md
+++ b/README.md
@@ -69,10 +69,35 @@ Please see the
 
 ## FAQ
 
-- Q: How to change Redis connection address / port?
+### Q: How to change Redis connection address / port?
 
-  A: Send `#targetUrl:` to `RsStreamSettings` default instance:
+A: Send `#targetUrl:` to `RsStreamSettings` default instance:
 
-  ```Smalltalk
-  RsStreamSettings default targetUrl: 'sync://localhost:6379'
-  ```
+```Smalltalk
+RsStreamSettings default targetUrl: 'sync://localhost:6379'
+```
+
+### Q: How do I use other event codecs?
+
+A: Set the event codec by sending `#eventCodec:` to the modelSpace's settings:
+
+```Smalltalk
+modelSpace settings eventCodec: #json.
+```
+
+The JSON codec is useful if you want to receive Historia events from other systems via the Redis event stream.
+
+If you need a more compact event format, you can use the MessagePack codec:
+
+```Smalltalk
+modelSpace settings eventCodec: #mp.
+```
+
+Note: The MessagePack codec is provided as an optional package. To use it, you must explicitly load it:
+
+```Smalltalk
+Metacello new
+  baseline: 'Historia';
+  repository: 'github://mumez/Historia:main/src';
+  load: #('MessagePackCodec').
+```

--- a/src/BaselineOfHistoria/BaselineOfHistoria.class.st
+++ b/src/BaselineOfHistoria/BaselineOfHistoria.class.st
@@ -55,9 +55,7 @@ BaselineOfHistoria >> optionBaselineMessagePack: spec [
 	spec
 		group: 'MessagePackCodec' with: #( 'Historia-Codec-MessagePack' );
 		group: 'MessagePackCodec-Tests'
-		with: #( 'Historia-Tests-Codec-MessagePack' );
-		group: 'MessagePackCodecAll'
-		with: #( 'MessagePackCodec' 'MessagePackCodec-Tests' )
+		with: #( 'Historia-Tests-Codec-MessagePack' )
 ]
 
 { #category : 'external projects' }

--- a/src/BaselineOfHistoria/BaselineOfHistoria.class.st
+++ b/src/BaselineOfHistoria/BaselineOfHistoria.class.st
@@ -10,7 +10,7 @@ BaselineOfHistoria >> baseline: spec [
 
 	<baseline>
 	spec for: #pharo do: [
-		self redistick: spec.
+		self rediStick: spec.
 		spec package: 'Historia-Core' with: [spec requires: #('RediStick')].
 		spec package: 'Historia-Codec'.
 		spec package: 'Historia-Event' with: [spec requires: #('Historia-Codec' 'Historia-Core')].
@@ -29,11 +29,39 @@ BaselineOfHistoria >> baseline: spec [
 			group: 'Tests' with: #( 'Historia-Tests' );
 			group: 'Examples' with: #('Historia-Examples-Bank');
 			group: 'Examples-Tests' with: #('Historia-Examples-Bank-Tests').
+		self optionBaselineMessagePack: spec.
 		]
 ]
 
 { #category : 'external projects' }
-BaselineOfHistoria >> redistick: spec [
+BaselineOfHistoria >> messagePack: spec [
+	spec
+		baseline: 'MessagePack'
+		with: [ spec
+				repository: 'github://msgpack/msgpack-smalltalk/repository';
+				loads: 'default' ]
+]
+
+{ #category : 'baseline' }
+BaselineOfHistoria >> optionBaselineMessagePack: spec [
+
+	self messagePack: spec.
+	spec
+		package: 'Historia-Codec-MessagePack'
+		with: [ spec requires: #( 'Historia-Codec' 'MessagePack' ) ].
+	spec package: 'Historia-Tests-Codec-MessagePack' with: [
+		spec requires:
+			#( 'Historia-Codec-MessagePack' 'Historia-Tests' 'Historia-Model' ) ].
+	spec
+		group: 'MessagePackCodec' with: #( 'Historia-Codec-MessagePack' );
+		group: 'MessagePackCodec-Tests'
+		with: #( 'Historia-Tests-Codec-MessagePack' );
+		group: 'MessagePackCodecAll'
+		with: #( 'MessagePackCodec' 'MessagePackCodec-Tests' )
+]
+
+{ #category : 'external projects' }
+BaselineOfHistoria >> rediStick: spec [
 	spec
 		baseline: 'RediStick'
 		with: [ spec

--- a/src/Historia-Codec-MessagePack/HsMessagePackCodec.class.st
+++ b/src/Historia-Codec-MessagePack/HsMessagePackCodec.class.st
@@ -1,0 +1,26 @@
+Class {
+	#name : 'HsMessagePackCodec',
+	#superclass : 'HsCodec',
+	#category : 'Historia-Codec-MessagePack',
+	#package : 'Historia-Codec-MessagePack'
+}
+
+{ #category : 'class initialization' }
+HsMessagePackCodec class >> initialize [
+	self register
+]
+
+{ #category : 'accessing' }
+HsMessagePackCodec class >> type [
+	^ #mp
+]
+
+{ #category : 'actions' }
+HsMessagePackCodec >> materialize: byteArray [
+	^ Object fromMessagePack: byteArray asByteArray
+]
+
+{ #category : 'actions' }
+HsMessagePackCodec >> serialize: objects [
+	^ objects messagePacked
+]

--- a/src/Historia-Codec-MessagePack/package.st
+++ b/src/Historia-Codec-MessagePack/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'Historia-Codec-MessagePack' }

--- a/src/Historia-Tests-Codec-MessagePack/HsMessagePackEventCodecTestCase.class.st
+++ b/src/Historia-Tests-Codec-MessagePack/HsMessagePackEventCodecTestCase.class.st
@@ -1,0 +1,49 @@
+Class {
+	#name : 'HsMessagePackEventCodecTestCase',
+	#superclass : 'HsEventCodecTestCase',
+	#category : 'Historia-Tests-Codec-MessagePack',
+	#package : 'Historia-Tests-Codec-MessagePack'
+}
+
+{ #category : 'fixtures' }
+HsMessagePackEventCodecTestCase >> eventCodecType [
+	^ #mp
+]
+
+{ #category : 'tests' }
+HsMessagePackEventCodecTestCase >> testAddValuesOnModelWithMessagePackCodec [
+	| spaceId modelSpace vmodel floatA symbolA dateAndTimeA modelSpace2 values2 vals eventEntry |
+	spaceId := 'test-ecAddValuesOnModelWithMessagePackCodec'.
+	modelSpace := HsModelSpace spaceId: spaceId.
+	modelSpace settings eventCodec: self eventCodecType.
+	modelSpace2 := HsModelSpace spaceId: spaceId.
+	self spaces: { modelSpace. modelSpace2 } do: [
+	self assert: modelSpace eventJournalStorage codecType equals: self eventCodecType.
+	modelSpace putModelOf: HsOrderedCollectionModel id: 'vals-1'.
+	vmodel := modelSpace modelAt: 'vals-1'.
+	vmodel add: (floatA := 3.141592653589793).
+	vmodel add: (symbolA := #symbol).
+	vmodel add: (dateAndTimeA := DateAndTime now).
+	vmodel save.
+	modelSpace eventPusher start.
+	modelSpace eventPusher waitEmptyFor: 200.
+	self assert: (modelSpace2 modelAt: 'vals-1') equals: nil.
+	
+	modelSpace2 catchup.
+	modelSpace eventPusher waitEmptyFor: 200.
+	values2 := modelSpace2 modelAt: 'vals-1'.
+	self assert: values2 size equals: 3.
+	self assertCollection: values2 asArray equals: vmodel values asArray.
+	vals := values2 values.
+	self assert: (vals at: 1) equals: floatA.
+	self assert: (vals at: 2) equals: symbolA.
+	self assert: (vals at: 3) equals: dateAndTimeA.
+	eventEntry := modelSpace eventJournalStorage eventStream last.
+	self assert: (eventEntry fieldAt: 'codec') equals: 'mp'.
+	]
+]
+
+{ #category : 'tests' }
+HsMessagePackEventCodecTestCase >> testSimpleEventCodec [
+	super testSimpleEventCodec
+]

--- a/src/Historia-Tests-Codec-MessagePack/package.st
+++ b/src/Historia-Tests-Codec-MessagePack/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'Historia-Tests-Codec-MessagePack' }


### PR DESCRIPTION
This pull request introduces support for a new codec, `MessagePack`, in the Historia project. The changes add the necessary baseline configurations, a new codec class, and corresponding test cases. Additionally, a typo in an existing method name was corrected. Below is a summary of the most important changes:

### MessagePack Codec Integration

* Added a new codec class, `HsMessagePackCodec`, under the `Historia-Codec-MessagePack` package. This class includes methods for serializing and materializing objects using the MessagePack format.
* Created a new test case class, `HsMessagePackEventCodecTestCase`, in the `Historia-Tests-Codec-MessagePack` package. This includes tests for verifying the integration of the MessagePack codec with event models and ensuring correct serialization and deserialization.
* Introduced a new package, `Historia-Codec-MessagePack`, to encapsulate the MessagePack codec implementation.
* Added a new package, `Historia-Tests-Codec-MessagePack`, to contain the test cases for the MessagePack codec.

### Baseline Configuration Updates

* Updated the `BaselineOfHistoria` class to include the new `MessagePackCodec` and `MessagePackCodec-Tests` groups, and added methods to define the baseline for the MessagePack codec.
* Modified the `.smalltalk.ston` file to load the `MessagePackCodec-Tests` group as part of the configuration.

### Miscellaneous Fix

* Fixed a typo in the method name `redistick:` by renaming it to `rediStick:` in the `BaselineOfHistoria` class.