### PR TITLE
MessagePack Codec and JSON Codec Support

### DIFF
--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -3,7 +3,7 @@ SmalltalkCISpec {
     SCIMetacelloLoadSpec {
       #baseline : 'Historia',
       #directory : 'src',
-      #load : [ 'Tests', 'Examples-Tests' 'MessagePackCodec-Tests'],
+      #load : [ 'Tests', 'Examples-Tests', 'MessagePackCodec-Tests'],
       #onConflict : #useLoaded,
       #useLatestMetacello : false,
       #onWarningLog : true,

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -3,7 +3,7 @@ SmalltalkCISpec {
     SCIMetacelloLoadSpec {
       #baseline : 'Historia',
       #directory : 'src',
-      #load : [ 'Tests', 'Examples-Tests'],
+      #load : [ 'Tests', 'Examples-Tests' 'MessagePackCodec-Tests'],
       #onConflict : #useLoaded,
       #useLatestMetacello : false,
       #onWarningLog : true,

--- a/README.md
+++ b/README.md
@@ -69,10 +69,35 @@ Please see the
 
 ## FAQ
 
-- Q: How to change Redis connection address / port?
+### Q: How to change Redis connection address / port?
 
-  A: Send `#targetUrl:` to `RsStreamSettings` default instance:
+A: Send `#targetUrl:` to `RsStreamSettings` default instance:
 
-  ```Smalltalk
-  RsStreamSettings default targetUrl: 'sync://localhost:6379'
-  ```
+```Smalltalk
+RsStreamSettings default targetUrl: 'sync://localhost:6379'
+```
+
+### Q: How do I use other event codecs?
+
+A: Set the event codec by sending `#eventCodec:` to the modelSpace's settings:
+
+```Smalltalk
+modelSpace settings eventCodec: #json.
+```
+
+The JSON codec is useful if you want to receive Historia events from other systems via the Redis event stream.
+
+If you need a more compact event format, you can use the MessagePack codec:
+
+```Smalltalk
+modelSpace settings eventCodec: #mp.
+```
+
+Note: The MessagePack codec is provided as an optional package. To use it, you must explicitly load it:
+
+```Smalltalk
+Metacello new
+  baseline: 'Historia';
+  repository: 'github://mumez/Historia:main/src';
+  load: #('MessagePackCodec').
+```

--- a/README.md
+++ b/README.md
@@ -99,5 +99,5 @@ Note: The MessagePack codec is provided as an optional package. To use it, you m
 Metacello new
   baseline: 'Historia';
   repository: 'github://mumez/Historia:main/src';
-  load: #('MessagePackCodec').
+  load: #('default' 'MessagePackCodec-Tests').
 ```

--- a/src/BaselineOfHistoria/BaselineOfHistoria.class.st
+++ b/src/BaselineOfHistoria/BaselineOfHistoria.class.st
@@ -55,9 +55,7 @@ BaselineOfHistoria >> optionBaselineMessagePack: spec [
 	spec
 		group: 'MessagePackCodec' with: #( 'Historia-Codec-MessagePack' );
 		group: 'MessagePackCodec-Tests'
-		with: #( 'Historia-Tests-Codec-MessagePack' );
-		group: 'MessagePackCodecAll'
-		with: #( 'MessagePackCodec' 'MessagePackCodec-Tests' )
+		with: #( 'Historia-Tests-Codec-MessagePack' )
 ]
 
 { #category : 'external projects' }

--- a/src/BaselineOfHistoria/BaselineOfHistoria.class.st
+++ b/src/BaselineOfHistoria/BaselineOfHistoria.class.st
@@ -10,7 +10,7 @@ BaselineOfHistoria >> baseline: spec [
 
 	<baseline>
 	spec for: #pharo do: [
-		self redistick: spec.
+		self rediStick: spec.
 		spec package: 'Historia-Core' with: [spec requires: #('RediStick')].
 		spec package: 'Historia-Codec'.
 		spec package: 'Historia-Event' with: [spec requires: #('Historia-Codec' 'Historia-Core')].
@@ -29,11 +29,39 @@ BaselineOfHistoria >> baseline: spec [
 			group: 'Tests' with: #( 'Historia-Tests' );
 			group: 'Examples' with: #('Historia-Examples-Bank');
 			group: 'Examples-Tests' with: #('Historia-Examples-Bank-Tests').
+		self optionBaselineMessagePack: spec.
 		]
 ]
 
 { #category : 'external projects' }
-BaselineOfHistoria >> redistick: spec [
+BaselineOfHistoria >> messagePack: spec [
+	spec
+		baseline: 'MessagePack'
+		with: [ spec
+				repository: 'github://msgpack/msgpack-smalltalk/repository';
+				loads: 'default' ]
+]
+
+{ #category : 'baseline' }
+BaselineOfHistoria >> optionBaselineMessagePack: spec [
+
+	self messagePack: spec.
+	spec
+		package: 'Historia-Codec-MessagePack'
+		with: [ spec requires: #( 'Historia-Codec' 'MessagePack' ) ].
+	spec package: 'Historia-Tests-Codec-MessagePack' with: [
+		spec requires:
+			#( 'Historia-Codec-MessagePack' 'Historia-Tests' 'Historia-Model' ) ].
+	spec
+		group: 'MessagePackCodec' with: #( 'Historia-Codec-MessagePack' );
+		group: 'MessagePackCodec-Tests'
+		with: #( 'Historia-Tests-Codec-MessagePack' );
+		group: 'MessagePackCodecAll'
+		with: #( 'MessagePackCodec' 'MessagePackCodec-Tests' )
+]
+
+{ #category : 'external projects' }
+BaselineOfHistoria >> rediStick: spec [
 	spec
 		baseline: 'RediStick'
 		with: [ spec

--- a/src/Historia-Codec-MessagePack/HsMessagePackCodec.class.st
+++ b/src/Historia-Codec-MessagePack/HsMessagePackCodec.class.st
@@ -1,0 +1,26 @@
+Class {
+	#name : 'HsMessagePackCodec',
+	#superclass : 'HsCodec',
+	#category : 'Historia-Codec-MessagePack',
+	#package : 'Historia-Codec-MessagePack'
+}
+
+{ #category : 'class initialization' }
+HsMessagePackCodec class >> initialize [
+	self register
+]
+
+{ #category : 'accessing' }
+HsMessagePackCodec class >> type [
+	^ #mp
+]
+
+{ #category : 'actions' }
+HsMessagePackCodec >> materialize: byteArray [
+	^ Object fromMessagePack: byteArray asByteArray
+]
+
+{ #category : 'actions' }
+HsMessagePackCodec >> serialize: objects [
+	^ objects messagePacked
+]

--- a/src/Historia-Codec-MessagePack/package.st
+++ b/src/Historia-Codec-MessagePack/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'Historia-Codec-MessagePack' }

--- a/src/Historia-Codec/HsJsonCodec.class.st
+++ b/src/Historia-Codec/HsJsonCodec.class.st
@@ -1,0 +1,21 @@
+Class {
+	#name : 'HsJsonCodec',
+	#superclass : 'HsCodec',
+	#category : 'Historia-Codec',
+	#package : 'Historia-Codec'
+}
+
+{ #category : 'accessing' }
+HsJsonCodec class >> type [
+	^ #json
+]
+
+{ #category : 'actions' }
+HsJsonCodec >> materialize: jsonString [
+	^ STONJSON fromString: jsonString
+]
+
+{ #category : 'actions' }
+HsJsonCodec >> serialize: objects [
+	^ STONJSON toString: objects
+]

--- a/src/Historia-Tests-Codec-MessagePack/HsMessagePackEventCodecTestCase.class.st
+++ b/src/Historia-Tests-Codec-MessagePack/HsMessagePackEventCodecTestCase.class.st
@@ -1,0 +1,49 @@
+Class {
+	#name : 'HsMessagePackEventCodecTestCase',
+	#superclass : 'HsEventCodecTestCase',
+	#category : 'Historia-Tests-Codec-MessagePack',
+	#package : 'Historia-Tests-Codec-MessagePack'
+}
+
+{ #category : 'fixtures' }
+HsMessagePackEventCodecTestCase >> eventCodecType [
+	^ #mp
+]
+
+{ #category : 'tests' }
+HsMessagePackEventCodecTestCase >> testAddValuesOnModelWithMessagePackCodec [
+	| spaceId modelSpace vmodel floatA symbolA dateAndTimeA modelSpace2 values2 vals eventEntry |
+	spaceId := 'test-ecAddValuesOnModelWithMessagePackCodec'.
+	modelSpace := HsModelSpace spaceId: spaceId.
+	modelSpace settings eventCodec: self eventCodecType.
+	modelSpace2 := HsModelSpace spaceId: spaceId.
+	self spaces: { modelSpace. modelSpace2 } do: [
+	self assert: modelSpace eventJournalStorage codecType equals: self eventCodecType.
+	modelSpace putModelOf: HsOrderedCollectionModel id: 'vals-1'.
+	vmodel := modelSpace modelAt: 'vals-1'.
+	vmodel add: (floatA := 3.141592653589793).
+	vmodel add: (symbolA := #symbol).
+	vmodel add: (dateAndTimeA := DateAndTime now).
+	vmodel save.
+	modelSpace eventPusher start.
+	modelSpace eventPusher waitEmptyFor: 200.
+	self assert: (modelSpace2 modelAt: 'vals-1') equals: nil.
+	
+	modelSpace2 catchup.
+	modelSpace eventPusher waitEmptyFor: 200.
+	values2 := modelSpace2 modelAt: 'vals-1'.
+	self assert: values2 size equals: 3.
+	self assertCollection: values2 asArray equals: vmodel values asArray.
+	vals := values2 values.
+	self assert: (vals at: 1) equals: floatA.
+	self assert: (vals at: 2) equals: symbolA.
+	self assert: (vals at: 3) equals: dateAndTimeA.
+	eventEntry := modelSpace eventJournalStorage eventStream last.
+	self assert: (eventEntry fieldAt: 'codec') equals: 'mp'.
+	]
+]
+
+{ #category : 'tests' }
+HsMessagePackEventCodecTestCase >> testSimpleEventCodec [
+	super testSimpleEventCodec
+]

--- a/src/Historia-Tests-Codec-MessagePack/package.st
+++ b/src/Historia-Tests-Codec-MessagePack/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'Historia-Tests-Codec-MessagePack' }

--- a/src/Historia-Tests/HsEventCodecTestCase.class.st
+++ b/src/Historia-Tests/HsEventCodecTestCase.class.st
@@ -5,40 +5,16 @@ Class {
 	#package : 'Historia-Tests'
 }
 
-{ #category : 'tests' }
-HsEventCodecTestCase >> testAddValuesOnModelWithJsonCodec [
-	| spaceId modelSpace vmodel modelSpace2 values2 eventEntry |
-	spaceId := 'test-ecAddValuesOnModelWithJsonCodec'.
-	modelSpace := HsModelSpace spaceId: spaceId.
-	modelSpace settings eventCodec: #json.
-	modelSpace2 := HsModelSpace spaceId: spaceId.
-	self spaces: { modelSpace. modelSpace2 } do: [
-	self assert: modelSpace eventJournalStorage codecType equals: #json.
-	modelSpace putModelOf: HsOrderedCollectionModel id: 'vals-1'.
-	vmodel := modelSpace modelAt: 'vals-1'.
-	1 to: 5 do: [ :idx | vmodel add: idx].
-	vmodel add: #symbol.
-	vmodel save.
-	modelSpace eventPusher start.
-	modelSpace eventPusher waitEmptyFor: 200.
-	self assert: (modelSpace2 modelAt: 'vals-1') equals: nil.
-	
-	modelSpace2 catchup.
-	modelSpace eventPusher waitEmptyFor: 200.
-	values2 := modelSpace2 modelAt: 'vals-1'.
-	self assert: values2 size equals: 6.
-	self assertCollection: values2 asArray equals: vmodel values asArray.
-	self assert: values2 values last equals: 'symbol'.
-	eventEntry := modelSpace eventJournalStorage eventStream last.
-	self assert: (eventEntry fieldAt: 'codec') equals: 'json'.
-	]
+{ #category : 'fixtures' }
+HsEventCodecTestCase >> eventCodecType [
+	^ #ston
 ]
 
 { #category : 'tests' }
-HsEventCodecTestCase >> testSimpleJsonCodec [
+HsEventCodecTestCase >> testSimpleEventCodec [
 	| storage ev  codecAndEventData eventData event |
 	storage := HsEventJournalStorage new.
-	storage settings eventCodec: #json.
+	storage settings eventCodec: self eventCodecType.
 	ev := HsEvent new.
 	ev argsAt: #a put: 'arg-1'.
 	ev undoArgsAt: #u put: 'uarg-1'.
@@ -46,7 +22,7 @@ HsEventCodecTestCase >> testSimpleJsonCodec [
 	ev originatorId: 'oid-1'.
 	ev userId: 'uid-1'.
  	codecAndEventData := (storage buildCodecAndEventData: ev) asDictionary.
-	self assert: storage codecType equals: #json.
+	self assert: storage codecType equals: self eventCodecType.
 	self assert: (codecAndEventData at: #codec) equals: storage codecType.
 	eventData := (HsCodec type: storage codecType) materialize: (codecAndEventData at: #data).
 	event := HsEvent id: 'id-1' data: eventData.

--- a/src/Historia-Tests/HsEventCodecTestCase.class.st
+++ b/src/Historia-Tests/HsEventCodecTestCase.class.st
@@ -1,0 +1,60 @@
+Class {
+	#name : 'HsEventCodecTestCase',
+	#superclass : 'HsBaseTestCase',
+	#category : 'Historia-Tests',
+	#package : 'Historia-Tests'
+}
+
+{ #category : 'tests' }
+HsEventCodecTestCase >> testAddValuesOnModelWithJsonCodec [
+	| spaceId modelSpace vmodel modelSpace2 values2 eventEntry |
+	spaceId := 'test-ecAddValuesOnModelWithJsonCodec'.
+	modelSpace := HsModelSpace spaceId: spaceId.
+	modelSpace settings eventCodec: #json.
+	modelSpace2 := HsModelSpace spaceId: spaceId.
+	self spaces: { modelSpace. modelSpace2 } do: [
+	self assert: modelSpace eventJournalStorage codecType equals: #json.
+	modelSpace putModelOf: HsOrderedCollectionModel id: 'vals-1'.
+	vmodel := modelSpace modelAt: 'vals-1'.
+	1 to: 5 do: [ :idx | vmodel add: idx].
+	vmodel add: #symbol.
+	vmodel save.
+	modelSpace eventPusher start.
+	modelSpace eventPusher waitEmptyFor: 200.
+	self assert: (modelSpace2 modelAt: 'vals-1') equals: nil.
+	
+	modelSpace2 catchup.
+	modelSpace eventPusher waitEmptyFor: 200.
+	values2 := modelSpace2 modelAt: 'vals-1'.
+	self assert: values2 size equals: 6.
+	self assertCollection: values2 asArray equals: vmodel values asArray.
+	self assert: values2 values last equals: 'symbol'.
+	eventEntry := modelSpace eventJournalStorage eventStream last.
+	self assert: (eventEntry fieldAt: 'codec') equals: 'json'.
+	]
+]
+
+{ #category : 'tests' }
+HsEventCodecTestCase >> testSimpleJsonCodec [
+	| storage ev  codecAndEventData eventData event |
+	storage := HsEventJournalStorage new.
+	storage settings eventCodec: #json.
+	ev := HsEvent new.
+	ev argsAt: #a put: 'arg-1'.
+	ev undoArgsAt: #u put: 'uarg-1'.
+	ev contextAt: #c put: 'ctx-1'.
+	ev originatorId: 'oid-1'.
+	ev userId: 'uid-1'.
+ 	codecAndEventData := (storage buildCodecAndEventData: ev) asDictionary.
+	self assert: storage codecType equals: #json.
+	self assert: (codecAndEventData at: #codec) equals: storage codecType.
+	eventData := (HsCodec type: storage codecType) materialize: (codecAndEventData at: #data).
+	event := HsEvent id: 'id-1' data: eventData.
+	self assert: (event eventId) equals: 'id-1'.
+	self assert: (event arguments) equals: { #a ->'arg-1' } asDictionary.
+	self assert: (event undoArgs) equals: { #u ->'uarg-1' } asDictionary.
+	self assert: (event context) equals: { #c ->'ctx-1' } asDictionary.
+	self assert: (event originatorId) equals: 'oid-1'.
+	self assert: (event userId) equals: 'uid-1'
+	
+]

--- a/src/Historia-Tests/HsJsonEventCodecTestCase.class.st
+++ b/src/Historia-Tests/HsJsonEventCodecTestCase.class.st
@@ -1,0 +1,45 @@
+Class {
+	#name : 'HsJsonEventCodecTestCase',
+	#superclass : 'HsEventCodecTestCase',
+	#category : 'Historia-Tests',
+	#package : 'Historia-Tests'
+}
+
+{ #category : 'fixtures' }
+HsJsonEventCodecTestCase >> eventCodecType [
+	^ #json
+]
+
+{ #category : 'tests' }
+HsJsonEventCodecTestCase >> testAddValuesOnModelWithJsonCodec [
+	| spaceId modelSpace vmodel modelSpace2 values2 eventEntry |
+	spaceId := 'test-ecAddValuesOnModelWithJsonCodec'.
+	modelSpace := HsModelSpace spaceId: spaceId.
+	modelSpace settings eventCodec: self eventCodecType.
+	modelSpace2 := HsModelSpace spaceId: spaceId.
+	self spaces: { modelSpace. modelSpace2 } do: [
+	self assert: modelSpace eventJournalStorage codecType equals: self eventCodecType.
+	modelSpace putModelOf: HsOrderedCollectionModel id: 'vals-1'.
+	vmodel := modelSpace modelAt: 'vals-1'.
+	1 to: 5 do: [ :idx | vmodel add: idx].
+	vmodel add: #symbol.
+	vmodel save.
+	modelSpace eventPusher start.
+	modelSpace eventPusher waitEmptyFor: 200.
+	self assert: (modelSpace2 modelAt: 'vals-1') equals: nil.
+	
+	modelSpace2 catchup.
+	modelSpace eventPusher waitEmptyFor: 200.
+	values2 := modelSpace2 modelAt: 'vals-1'.
+	self assert: values2 size equals: 6.
+	self assertCollection: values2 asArray equals: vmodel values asArray.
+	self assert: values2 values last equals: 'symbol'.
+	eventEntry := modelSpace eventJournalStorage eventStream last.
+	self assert: (eventEntry fieldAt: 'codec') equals: 'json'.
+	]
+]
+
+{ #category : 'tests' }
+HsJsonEventCodecTestCase >> testSimpleEventCodec [
+	super testSimpleEventCodec
+]


### PR DESCRIPTION
This pull request introduces support for the MessagePack codec in the Historia project, along with tests and related documentation updates. It also includes a minor fix for a method name and adds a JSON codec implementation. Below are the key changes grouped by theme:

### MessagePack Codec Support:
* Added `HsMessagePackCodec` class for serializing and materializing data using the MessagePack format. (`src/Historia-Codec-MessagePack/HsMessagePackCodec.class.st`, [src/Historia-Codec-MessagePack/HsMessagePackCodec.class.stR1-R26](diffhunk://#diff-da4bef485a51f80160daac86ef2f7a0a15c97f7d11435378c7e99998c5c21912R1-R26))
* Introduced `optionBaselineMessagePack` method in `BaselineOfHistoria` to load MessagePack-related packages and dependencies. (`src/BaselineOfHistoria/BaselineOfHistoria.class.st`, [src/BaselineOfHistoria/BaselineOfHistoria.class.stR32-R62](diffhunk://#diff-7077448cd81333cd47095039848cef7c1642bd27fd2267e37f8044153ac5a53fR32-R62))
* Added `HsMessagePackEventCodecTestCase` to test MessagePack codec functionality, including event serialization and deserialization. (`src/Historia-Tests-Codec-MessagePack/HsMessagePackEventCodecTestCase.class.st`, [src/Historia-Tests-Codec-MessagePack/HsMessagePackEventCodecTestCase.class.stR1-R49](diffhunk://#diff-54a05e37e3e6081af5ec84fe31233f069dba1b0b24a7b3c3b081ae8d481dbd1fR1-R49))

### JSON Codec Implementation:
* Added `HsJsonCodec` class for handling JSON serialization and materialization. (`src/Historia-Codec/HsJsonCodec.class.st`, [src/Historia-Codec/HsJsonCodec.class.stR1-R21](diffhunk://#diff-a94eff826ffc4e76909653f9289e13640e48a32d336b78b9ce3e1bbaed3e8e6eR1-R21))
* Introduced `HsJsonEventCodecTestCase` to validate JSON codec behavior, including event handling and integration with the model space. (`src/Historia-Tests/HsJsonEventCodecTestCase.class.st`, [src/Historia-Tests/HsJsonEventCodecTestCase.class.stR1-R45](diffhunk://#diff-d96b194f9583d2a7398507253018acfbd837ca5686e7f05896f097f1f1315bd6R1-R45))

### Documentation Updates:
* Updated `README.md` with instructions on using event codecs (JSON and MessagePack), including loading the optional MessagePack package. (`README.md`, [README.mdL72-R103](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L72-R103))

### Minor Fix:
* Fixed a typo in the method name `redistick:` to `rediStick:` in `BaselineOfHistoria`. (`src/BaselineOfHistoria/BaselineOfHistoria.class.st`, [src/BaselineOfHistoria/BaselineOfHistoria.class.stL13-R13](diffhunk://#diff-7077448cd81333cd47095039848cef7c1642bd27fd2267e37f8044153ac5a53fL13-R13))

### Test Infrastructure Enhancements:
* Added `HsEventCodecTestCase` as a base class for testing event codecs, providing a shared framework for JSON and MessagePack codec tests. (`src/Historia-Tests/HsEventCodecTestCase.class.st`, [src/Historia-Tests/HsEventCodecTestCase.class.stR1-R36](diffhunk://#diff-d53cb2c4382958bc22aa2ad78ab7ef63f034afe08f289c497b695f2018b214ceR1-R36))